### PR TITLE
feat(refs DPLAN-12170): allow declining optional cookies instantly

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -67,22 +67,28 @@
     padding: 6px 11px;
 }
 
-.dp-consent-button--primary {
-    color: #fff;
-    background-color: #006fd0;
+.dp-consent-button--primary-outline {
+    color: #006fd0;
+    background-color: #fff;
+    border: 1px solid #006fd0;
 }
 
-.dp-consent-button--primary:hover {
+.dp-consent-button--primary-outline:hover {
+    color: #fff;
     background-color: #005EB1;
+    border: 1px solid #006fd0;
 }
 
-.dp-consent-button--secondary {
+.dp-consent-button--secondary-outline {
+    color: #808080;
+    background-color: #fff;
+    border: 1px solid #808080;
+}
+
+.dp-consent-button--secondary-outline:hover {
     color: #fff;
-    background-color: #808080;
-}
-
-.dp-consent-button--secondary:hover {
     background-color: #696969;
+    border: 1px solid #808080;
 }
 
 .dp-consent-modal__button {
@@ -144,17 +150,17 @@
 }
 
 @media (max-width: 767px) {
-  .dp-consent-modal__cookie-item {
-    flex-direction: column;
-  }
+    .dp-consent-modal__cookie-item {
+        flex-direction: column;
+    }
 
-  .dp-consent-modal__cookie-item div:first-child {
-    width: 100%;
-    padding-bottom: 6px;
-  }
+    .dp-consent-modal__cookie-item div:first-child {
+        width: 100%;
+        padding-bottom: 6px;
+    }
 
-  .dp-consent-modal__cookie-item div:last-child {
-    width: 100%;
-  }
+    .dp-consent-modal__cookie-item div:last-child {
+        width: 100%;
+    }
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -67,25 +67,25 @@
     padding: 6px 11px;
 }
 
-.dp-consent-button--primary-outline {
+.dp-consent-button--primary {
     color: #006fd0;
     background-color: #fff;
     border: 1px solid #006fd0;
 }
 
-.dp-consent-button--primary-outline:hover {
+.dp-consent-button--primary:hover {
     color: #fff;
     background-color: #005EB1;
     border: 1px solid #006fd0;
 }
 
-.dp-consent-button--secondary-outline {
+.dp-consent-button--secondary {
     color: #808080;
     background-color: #fff;
     border: 1px solid #808080;
 }
 
-.dp-consent-button--secondary-outline:hover {
+.dp-consent-button--secondary:hover {
     color: #fff;
     background-color: #696969;
     border: 1px solid #808080;

--- a/src/js/MatomoConsent.js
+++ b/src/js/MatomoConsent.js
@@ -4,7 +4,7 @@ function createButton (textContent, id, type) {
   button.setAttribute('data-dp-consent', id)
   button.textContent = textContent
   button.classList.add('dp-consent-button')
-  var buttonStyle = type === 'primary' ? 'dp-consent-button--primary' : 'dp-consent-button--secondary'
+  var buttonStyle = type === 'primary' ? 'dp-consent-button--primary-outline' : 'dp-consent-button--secondary-outline'
   button.classList.add(buttonStyle)
   return button
 }

--- a/src/js/MatomoConsent.js
+++ b/src/js/MatomoConsent.js
@@ -4,7 +4,7 @@ function createButton (textContent, id, type) {
   button.setAttribute('data-dp-consent', id)
   button.textContent = textContent
   button.classList.add('dp-consent-button')
-  var buttonStyle = type === 'primary' ? 'dp-consent-button--primary-outline' : 'dp-consent-button--secondary-outline'
+  var buttonStyle = type === 'primary' ? 'dp-consent-button--primary' : 'dp-consent-button--secondary'
   button.classList.add(buttonStyle)
   return button
 }

--- a/src/js/MatomoConsent.js
+++ b/src/js/MatomoConsent.js
@@ -63,7 +63,7 @@ function createNecessaryCookies (cookies) {
 
 function createNotice (notice) {
   var noticeContainer = document.createElement('div')
-  noticeContainer.appendChild(document.createTextNode(notice))
+  noticeContainer.innerHTML = notice
   return noticeContainer
 }
 

--- a/src/js/MatomoConsent.js
+++ b/src/js/MatomoConsent.js
@@ -12,8 +12,9 @@ function createButton (textContent, id, type) {
 function createConsentSliderButtons () {
   var buttons = document.createElement('div')
   buttons.classList.add('dp-consent-slider__buttons')
-  buttons.appendChild(createButton('Alle akzeptieren', 'accept_all', 'primary'))
-  buttons.appendChild(createButton('Einstellungen ändern', 'change_settings'))
+  buttons.appendChild(createButton('Zustimmen', 'accept_all', 'primary'))
+  buttons.appendChild(createButton('Ablehnen', 'decline_optional', 'primary'))
+  buttons.appendChild(createButton('Überprüfen', 'change_settings'))
   return buttons
 }
 
@@ -175,6 +176,12 @@ function dpConsent (config) {
       trackingConsent.given = true
       removeDpConsentElements()
     }
+
+    if (targetId === 'decline_optional') {
+      trackingConsent.given = false
+      removeDpConsentElements()
+    }
+
     if (targetId === 'change_settings') {
       showSettingsModal()
     }


### PR DESCRIPTION
**Ticket:** [DPLAN-12170](https://demoseurope.youtrack.cloud/issue/DPLAN-12170/ADO-14277-Consent-Bar-aktualisieren)

- According to the GDPR, declining optional cookies should be possible directly in the consent bar without having to navigate anywhere else; this is implemented in this PR
- Since 'Accept' and 'Decline' buttons should have the same styling, they are changed to the less obtrusive outline buttons
- It should be possible to pass links into the consent bar (via the `notice` string parameter)